### PR TITLE
Add `ClosePosition` method to trading API and integrate into executor service

### DIFF
--- a/pkg/core/executor/svc.go
+++ b/pkg/core/executor/svc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/ksysoev/deriv-bot/pkg/core/signal"
 )
@@ -59,9 +60,13 @@ func (s *Service) ExecuteStrategy(ctx context.Context, token, symbol string, amo
 				return fmt.Errorf("failed to execute buy for symbol %s: %w", symbol, err)
 			}
 
+			time.Sleep(2 * time.Second) // Simulate some processing time
+
 			if err := s.tradingProv.ClosePosition(ctx, id); err != nil {
 				return fmt.Errorf("failed to close position for contract ID %d: %w", id, err)
 			}
+
+			return nil
 		}
 	}
 

--- a/pkg/prov/deriv/trade.go
+++ b/pkg/prov/deriv/trade.go
@@ -63,3 +63,20 @@ func (a *API) Sell(ctx context.Context, symbol string, amount, price float64, le
 
 	return res.Buy.ContractId, nil
 }
+
+// ClosePosition closes an open trading position for a given contract ID.
+// It performs a sell operation at the market price to close the position.
+// Accepts ctx to manage request lifecycle and contractID identifying the position to close.
+// Returns an error if the API request to close the position fails.
+func (a *API) ClosePosition(ctx context.Context, contractID int) error {
+	_, err := a.client.Sell(ctx, schema.Sell{
+		Sell:  contractID,
+		Price: 0, // Sell at market price, we may want to allow specifying a price in the future
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to close position %d: %w", contractID, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This pull request introduces functionality to close trading positions by adding a `ClosePosition` method to the `TradingProvider` interface and implementing it in the service and API layers. The changes ensure that positions can be closed programmatically after a buy operation, enhancing the trading workflow.

### Enhancements to trading functionality:

* **Interface update**: Added `ClosePosition(ctx context.Context, contractID int) error` to the `TradingProvider` interface in `pkg/core/executor/svc.go`. This provides a standardized method for closing trading positions.

* **Service logic update**: Modified `ExecuteStrategy` in `pkg/core/executor/svc.go` to call `ClosePosition` after a successful buy operation. This ensures positions are closed programmatically, with error handling for both buy and close operations.

* **API implementation**: Added the `ClosePosition` method to the `API` struct in `pkg/prov/deriv/trade.go`. This method performs a sell operation at market price to close the position, with detailed error handling.